### PR TITLE
Create version flag in CLI for outputting the current module version

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,6 +14,7 @@ Install with `npm install travisjs -g`
 Usage: travisjs <command>
 
 command
+  version    display the current version
   init       initialize travis (hook and yml)
   badge      generate badge
   open       open travis page

--- a/bin/travisjs.js
+++ b/bin/travisjs.js
@@ -9,6 +9,13 @@ var program = require('nomnom')
   .script('travisjs')
   ;
   
+program.command('version')
+  .help('display the current version')
+  .callback(function () {
+      return require('../package').version;
+  })
+  ;
+
 program.command('init')
   .help('initialize travis (hook and yml)')
   .callback(function (opts) {


### PR DESCRIPTION
Output the current `package.json` version.

----

One small thing, this will cause the `-h`/`--help` usage output to show an empty options list.
I opened a pull-request https://github.com/harthur/nomnom/pull/55 to fix that issue.