### PR TITLE
Read Node versions from travisjs config

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -113,7 +113,7 @@ Travis.prototype.open = function () {
 Travis.prototype.yml = function () {
   var opts = {
     language: 'node_js',
-    node_js: ['0.10', '0.8']
+    node_js: this.configstore.get('node_js') || ['0.10', '0.8']
   }
   var yml = yaml.stringify(opts, 10);
   console.log('Writing .travis.yml:');


### PR DESCRIPTION
This patchs makes `travisjs` look up `node_js` field in its config file.